### PR TITLE
Removed multiprocessing from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,3 @@ soupsieve==2.2
 urllib3==1.26.5
 webencodings==0.5.1
 mysql-connector-python==8.0.26
-multiprocessing==2.6.2.1


### PR DESCRIPTION
Multiprocessing is already pre-installed in python 3 and it is of no need to install it. Infact trying to install it throws back an error. 